### PR TITLE
Fix for Fire and Forget, and multiple calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+# Changelog

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -21,7 +21,6 @@ dependencies {
     compile('io.netifi.proteus:proteus-core:0.2.1') {
         transitive = false
     }
-
     testCompile 'junit:junit:4.10'
 
     testCompile 'org.apache.logging.log4j:log4j-api:2.8.2'

--- a/core/src/main/java/io/netifi/sdk/rs/DefaultNetifiSocket.java
+++ b/core/src/main/java/io/netifi/sdk/rs/DefaultNetifiSocket.java
@@ -63,7 +63,7 @@ public class DefaultNetifiSocket implements NetifiSocket {
   }
 
   public ByteBuf getRoute() {
-    return route;
+    return route.asReadOnly();
   }
 
   @Override

--- a/core/src/test/java/io/netifi/sdk/rs/ProteusRoutingIntegrationTest.java
+++ b/core/src/test/java/io/netifi/sdk/rs/ProteusRoutingIntegrationTest.java
@@ -1,15 +1,18 @@
 package io.netifi.sdk.rs;
 
+import com.google.protobuf.Empty;
 import io.netifi.sdk.Netifi;
 import io.netifi.testing.protobuf.*;
 import java.time.Duration;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.reactivestreams.Publisher;
+import reactor.core.publisher.EmitterProcessor;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
@@ -93,7 +96,7 @@ public class ProteusRoutingIntegrationTest {
     SimpleServiceClient simpleServiceClient = new SimpleServiceClient(netifiSocket);
 
     Flux<SimpleRequest> map =
-        Flux.range(1, 100_000)
+        Flux.range(1, 100)
             .publishOn(Schedulers.parallel(), 32)
             .map(i -> SimpleRequest.newBuilder().setRequestMessage("a message -> " + i).build());
 
@@ -105,8 +108,42 @@ public class ProteusRoutingIntegrationTest {
 
     System.out.println(response.getResponseMessage());
   }
+  
+  @Test
+  public void testFireAndForget() throws Exception {
+    int count = 1000;
+    CountDownLatch latch = new CountDownLatch(count);
+    SimpleServiceClient client = new SimpleServiceClient(netifiSocket);
+    client
+        .streamOnFireAndForget(Empty.getDefaultInstance())
+        .subscribe(simpleResponse -> latch.countDown());
+    Flux.range(1, count)
+        .flatMap(
+            i ->
+                client.fireAndForget(
+                    SimpleRequest.newBuilder().setRequestMessage("fire -> " + i).build()))
+        .subscribe();
+    latch.await();
+  }
 
   static class DefaultSimpleService implements SimpleService {
+    EmitterProcessor<SimpleRequest> messages = EmitterProcessor.create();
+  
+    @Override
+    public Mono<Void> fireAndForget(SimpleRequest message) {
+      messages.onNext(message);
+      return Mono.empty();
+    }
+  
+    @Override
+    public Flux<SimpleResponse> streamOnFireAndForget(Empty message) {
+      return messages.map(
+          simpleRequest ->
+              SimpleResponse.newBuilder()
+                  .setResponseMessage("got fire and forget -> " + simpleRequest.getRequestMessage())
+                  .build());
+    }
+    
     @Override
     public Mono<SimpleResponse> unaryRpc(SimpleRequest message) {
       return Mono.fromCallable(

--- a/core/src/test/proto/io.netifi.sdk.proteus/simpleservice.proto
+++ b/core/src/test/proto/io.netifi.sdk.proteus/simpleservice.proto
@@ -2,12 +2,20 @@ syntax = "proto3";
 
 package io.netifi.testing;
 
+import "google/protobuf/empty.proto";
+
 option java_package = "io.netifi.testing.protobuf";
 option java_outer_classname = "SimpleServiceProto";
 option java_multiple_files = true;
 
 // A simple service for test.
 service SimpleService {
+  // fire and forget
+  rpc FireAndForget (SimpleRequest) returns (google.protobuf.Empty) {}
+
+  // Streams when you send a Fire and Forget
+  rpc StreamOnFireAndForget (google.protobuf.Empty) returns (stream SimpleResponse) {}
+
   // Simple unary RPC.
   rpc UnaryRpc (SimpleRequest) returns (SimpleResponse) {}
 

--- a/core/src/test/resources/log4j2.xml
+++ b/core/src/test/resources/log4j2.xml
@@ -12,7 +12,7 @@
         <logger name="io.netifi" level="DEBUG" additivity="false">
             <AppenderRef ref="STDOUT"/>
         </logger>
-        <logger name="io.rsocket.FrameLogger" level="info" additivity="false">
+        <logger name="io.rsocket.FrameLogger" level="error" additivity="false">
             <AppenderRef ref="STDOUT"/>
         </logger>
     </Loggers>


### PR DESCRIPTION
DefaultNetifiSocket needed to call .asReadOnly when returning internal route bytebuf

Addresses the following issues
https://github.com/netifi/netifi-sdk-java/issues/5
https://github.com/netifi/netifi-sdk-java/issues/4
https://github.com/netifi/netifi-sdk-java/issues/1